### PR TITLE
remove restrictive checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 CC = gcc
+CFLAGS += -g -O0 -Wall
+CFLAGS += -I./include
 
 all : ar9300_eeprom
 
 DEF_INC = include/ar9300_eeprom.h include/eeprom.h include/types.h include/ar9003_eeprom.h
 
-ar9300_eeprom : CFLAGS = -Wall -O2 -I./include
-ar9300_eeprom : LDLIBS =
+#ar9300_eeprom : CFLAGS = -Wall -O2 -I./include
+#ar9300_eeprom : LDLIBS =
 ar9300_eeprom : ar9300_eeprom.o detect_eeprom.o dump_eeprom.o io_eeproms.o
 ar9300_eeprom.o : ar9300_eeprom.c $(DEF_INC) include/wdr4300.h
 detect_eeprom.o : detect_eeprom.c $(DEF_INC)

--- a/detect_eeprom.c
+++ b/detect_eeprom.c
@@ -13,6 +13,7 @@ bool default_detect(struct ar9300_eeprom eeproms[], const void *data)
         if (!ddd->allow2G && !ddd->allow5G)
             return true;
 
+#if 0
         if (!(memcmp(ddd->params_for_tuning_caps, eeprom->baseEepHeader.params_for_tuning_caps, sizeof(ddd->params_for_tuning_caps)) == 0 &&
             ddd->allow2G == !!(eeprom->baseEepHeader.opCapFlags.opFlags & AR5416_OPFLAGS_11G) &&
             (!ddd->allow2G || memcmp(ddd->calFreqPier2G, eeprom->calFreqPier2G, sizeof(ddd->calFreqPier2G)) == 0) &&
@@ -21,6 +22,7 @@ bool default_detect(struct ar9300_eeprom eeproms[], const void *data)
             (!ddd->allow5G || memcmp(ddd->calFreqPier5G, eeprom->calFreqPier5G, sizeof(ddd->calFreqPier5G)) == 0) &&
             (!ddd->allow5G || memcmp(ddd->calPierData5G, eeprom->calPierData5G, sizeof(ddd->calPierData5G)) == 0)))
             return false;
+#endif
     }
 
     return true;


### PR DESCRIPTION
I wanted to just file an issue, really, but pulls are the only way :)

given the structure of the code, I needed -g to step through this and work out why it produced no output.  

Just because the board isn't a known version, it should still attempt to decode the output, surely?!

I suggest that if values of a layout are all 0xff, that it should be considered invalid.  A dump from my carambola2 module art partition is available at: http://paste.fedoraproject.org/253373/39205928/ for a while at least.  (note that the second partition is all 0xfffff)
